### PR TITLE
fix gradle error due to sdk 30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,13 +6,13 @@ apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         applicationId "com.plcoding.spotifycloneyt"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -95,7 +95,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.1.1'
 
     // ExoPlayer
-    api "com.google.android.exoplayer:exoplayer-core:2.11.8"
-    api "com.google.android.exoplayer:exoplayer-ui:2.11.8"
-    api "com.google.android.exoplayer:extension-mediasession:2.11.8"
+    api "com.google.android.exoplayer:exoplayer-core:2.19.1"
+    api "com.google.android.exoplayer:exoplayer-ui:2.19.1"
+    api "com.google.android.exoplayer:extension-mediasession:2.19.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.4.0"
     repositories {
@@ -24,4 +23,10 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+configurations.configureEach {
+    resolutionStrategy {
+        force 'androidx.core:core-ktx:1.3.1'
+    }
 }


### PR DESCRIPTION
Gradle error due to SDK 30. Upgraded SDK to 31

I got this error while building the project

> Android resource linking failed /Users/xxx/.gradle/caches/transforms-2/files-2.1/5d04bb4852dc27334fe36f129faf6500/res/values/values.xml:115:5-162:25: AAPT: error: resource android:attr/lStar not found.

Solution: https://stackoverflow.com/a/69050529/9076662